### PR TITLE
corrected the exit key print statement

### DIFF
--- a/autoclicker.py
+++ b/autoclicker.py
@@ -32,7 +32,7 @@ def display_controls():
     print("// - Controls:")
     print("\t F1 = Resume")
     print("\t F2 = Pause")
-    print("\t F3 = Exit")
+    print("\t Esc = Exit")
     print("-----------------------------------------------------")
     print('Press F1 to start ...')
 


### PR DESCRIPTION
In print statement it was "F3" to exit but it was mapped to "esc" key